### PR TITLE
Fix building issues up to kernel 6.12

### DIFF
--- a/include/os/rt_linux.h
+++ b/include/os/rt_linux.h
@@ -70,7 +70,11 @@
 #include <linux/unistd.h>
 #include <asm/uaccess.h>
 #include <asm/types.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#include <linux/unaligned.h>	/* for get_unaligned() */
+#else
 #include <asm/unaligned.h>	/* for get_unaligned() */
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27)
 #include <linux/pid.h>

--- a/os/linux/cfg80211/cfg80211.c
+++ b/os/linux/cfg80211/cfg80211.c
@@ -2850,12 +2850,20 @@ static int CFG80211_OpsStartAp(
 static int CFG80211_OpsChangeBeacon(
 	struct wiphy *pWiphy,
 	struct net_device *netdev,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
+	struct cfg80211_ap_update *params)
+#else
 	struct cfg80211_beacon_data *info)
+#endif
 {
 	VOID *pAd;
 	CMD_RTPRIV_IOCTL_80211_BEACON bcn;
 	UCHAR *beacon_head_buf = NULL;
 	UCHAR *beacon_tail_buf = NULL;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
+	struct cfg80211_beacon_data *info = &params->beacon;
+#endif
     
     MAC80211_PAD_GET(pAd, pWiphy);	
     CFG80211DBG(RT_DEBUG_TRACE, ("80211> %s ==>\n", __FUNCTION__));

--- a/os/linux/cfg80211/cfg80211.c
+++ b/os/linux/cfg80211/cfg80211.c
@@ -2311,6 +2311,9 @@ static int CFG80211_OpsTdlsMgmt
 #else
     IN u8 *peer,
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0))
+    IN int link_id,
+#endif
     IN u8 action_code, 
     IN u8 dialog_token,
     IN u16 status_code,
@@ -2328,6 +2331,9 @@ static int CFG80211_OpsTdlsMgmt
 	VOID *pAd;
 	MAC80211_PAD_GET(pAd, pWiphy);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0))
+	CFG80211DBG(RT_DEBUG_WARN, ("80211> link_id: %d\n", link_id));
+#endif
 	CFG80211DBG(RT_DEBUG_WARN, ("80211> extra_ies_len : %zd ==>\n", extra_ies_len));
 
 	switch (action_code) {


### PR DESCRIPTION
[Linux Kernel 6.5]
-  Callback CFG80211_OpsTdlsMgmt was updated with the expected prototype for Linux 6.5 kernels.
    Now includes link_id parameter.
    See: linux/net/mac80211/tdls.c file, ieee80211_tdls_mgmt function

[Linux Kernel 6.7]
-  Callback CFG80211_OpsChangeBeacon was updated with the expected prototype for Linux 6.7 kernels. 
    Now cfg80211_ap_update structure contains beacon data.
    See: linux/net/mac80211/cfg.c file, ieee80211_change_beacon function

[Linux Kernel 6.12]
- Rename asm/unaligned.h to linux/unaligned.h for Linux 6.12 kernels.
   See: [move asm/unaligned.h to linux/unaligned.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5f60d5f6bbc12e782fac78110b0ee62698f3b576)

    

